### PR TITLE
add __abs__ for cfix and sfix

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -1694,6 +1694,10 @@ class cfix(_number):
     def __neg__(self):
         # cfix type always has .v
         return cfix(-self.v)
+
+    @vectorize
+    def __abs__(self):
+        return self * cint(self.v >= 0) - self * cint(self.v < 0)
     
     def __rsub__(self, other):
         return -self + other
@@ -1872,6 +1876,10 @@ class sfix(_number):
     @vectorize
     def __neg__(self):
         return sfix(-self.v)
+
+    @vectorize
+    def __abs__(self):
+        return self * sint(self.v >= 0) - self * sint(self.v < 0)
 
     def __rsub__(self, other):
         return -self + other

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -1697,7 +1697,8 @@ class cfix(_number):
 
     @vectorize
     def __abs__(self):
-        return self * cint(self.v >= 0) - self * cint(self.v < 0)
+        neg_flag = self.v < 0
+        return self * cint(1 - 2 * neg_flag)
     
     def __rsub__(self, other):
         return -self + other
@@ -1879,7 +1880,8 @@ class sfix(_number):
 
     @vectorize
     def __abs__(self):
-        return self * sint(self.v >= 0) - self * sint(self.v < 0)
+        neg_flag = self.v < 0
+        return self * sint(1 - 2 * neg_flag)
 
     def __rsub__(self, other):
         return -self + other

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -1698,7 +1698,7 @@ class cfix(_number):
     @vectorize
     def __abs__(self):
         neg_flag = self.v < 0
-        return self * cint(1 - 2 * neg_flag)
+        return self - cint(neg_flag) * (self + self)
     
     def __rsub__(self, other):
         return -self + other
@@ -1881,7 +1881,7 @@ class sfix(_number):
     @vectorize
     def __abs__(self):
         neg_flag = self.v < 0
-        return self * sint(1 - 2 * neg_flag)
+        return self - sint(neg_flag) * (self + self)
 
     def __rsub__(self, other):
         return -self + other


### PR DESCRIPTION
tested with these code
```python
a = cfix(0.02)
b = cfix(-0.02)
c = sfix(0.02)
d = sfix(-0.02)

test(abs(a), a)
test(abs(b), -b)

test(abs(c), a)
test(abs(d), -b)
```