### PR TITLE
Added missing destructor-functions for memory-based types

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2481,7 +2481,9 @@ class sfixMatrix(Matrix):
         self.rows = rows
         self.columns = columns
         self.multi_array = Matrix(rows, columns, sint, address)
-        self.address = self.multi_array.address
+    
+    def delete(self):
+        self.multi_array.delete()
 
     def __getitem__(self, index):
         return sfixArray(self.columns, self.multi_array[index].address)

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2459,9 +2459,11 @@ class sfloatMatrix(Matrix):
 class sfixArray(Array):
     def __init__(self, length, address=None):
         self.array = Array(length, sint, address)
-        self.address = self.array.address
         self.length = length
         self.value_type = sfix
+        
+    def delete()
+        self.array.delete()
 
     def __getitem__(self, index):
         if isinstance(index, slice):

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2356,8 +2356,7 @@ class Matrix(object):
         self.address = Array(rows * columns, value_type, address).address
         
     def delete(self):
-        if program:
-            program.free(self.address, self.value_type.reg_type)
+        Array.delete(self)
 
     def __getitem__(self, index):
         return Array(self.columns, self.value_type, \
@@ -2462,7 +2461,7 @@ class sfixArray(Array):
         self.length = length
         self.value_type = sfix
         
-    def delete()
+    def delete(self):
         self.array.delete()
 
     def __getitem__(self, index):

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2353,10 +2353,11 @@ class Matrix(object):
         if value_type in _types:
             value_type = _types[value_type]
         self.value_type = value_type
-        self.address = Array(rows * columns, value_type, address).address
+        self.array = Array(rows * columns, value_type, address)
+        self.address = self.array.address
         
     def delete(self):
-        Array.delete(self)
+        self.array.delete()
 
     def __getitem__(self, index):
         return Array(self.columns, self.value_type, \


### PR DESCRIPTION
In the Compiler I added destructor methods `delete()` which call the destructor of the underlying memory-allocation or types recursively. Namely, I changed `Matrix`, `MultiArray`, `VectorArray`, `sfloatArray`, `sfloatMatrix`, `sfixArray`, `sfixMatrix`, `MemFloat`, `MemFix`.
