### PR TITLE
Fix bug of sfixMatrix.__mul__()

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2442,7 +2442,7 @@ class sfloatMatrix(Matrix):
 
 class sfixArray(Array):
     def __init__(self, length, address=None):
-        self.array = Array(length, sint, address)
+        self.array = Array(length, sfix, address)
         self.length = length
         self.value_type = sfix
 
@@ -2463,10 +2463,13 @@ class sfixMatrix(Matrix):
     def __init__(self, rows, columns, address=None):
         self.rows = rows
         self.columns = columns
-        self.multi_array = Matrix(rows, columns, sint, address)
+        self.multi_array = Matrix(rows, columns, sfix, address)
 
     def __getitem__(self, index):
         return sfixArray(self.columns, self.multi_array[index].address)
+    
+    def __mul__(self, other):
+        return self.multi_array * other
 
     def get_address(self):
         return self.multi_array.get_address()


### PR DESCRIPTION
sfixMatrix * some_array will throw this error

```
Traceback (most recent call last):
  File "./compile.py", line 88, in <module>
    main()
  File "./compile.py", line 85, in main
    compilation()
  File "./compile.py", line 72, in compilation
    assemblymode=options.assemblymode, debug=options.debug)
  File "/root/mpc/MP-SPDZ/Compiler/compilerLib.py", line 57, in run
    execfile(prog.infile, VARS)
  File "/root/mpc/MP-SPDZ/Programs/Source/cotton2.mpc", line 18, in <module>
    mul_result = A * t
  File "/root/mpc/MP-SPDZ/Compiler/types.py", line 2688, in __mul__
    assert len(other) == self.sizes[1]
AttributeError: 'sfixMatrix' object has no attribute 'sizes'
```

I guess that's because `self` now points to sfixMatrix while `__mul__` is using its super-class Matrix's.